### PR TITLE
prevent display empty foreach errors

### DIFF
--- a/block-user.php
+++ b/block-user.php
@@ -86,6 +86,10 @@ class BBP_Block_User {
         $user    = wp_get_current_user();
         $blocked = get_option( '_bbp_block_user_list', array() );
         $blocked = explode( "\n", $blocked );
+        
+		if ( empty( $blocked ) ) {
+			return true;
+		}
 
         if ( in_array( $user->user_login, $blocked ) ) {
             return false;


### PR DESCRIPTION
initial release shows an error in front page if the blocklist are empty.
